### PR TITLE
Fix/elsewhere frequency match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+wordle-env


### PR DESCRIPTION
sometimes, the 'marked' letters imply that a letter 'elsewhere' must appear in the target word a minimum number of times

in the screenshot attached the wordle is 'alpha' and the guesses are 'start' and 'avian'

the previous implementaion would allow 'almeh' (among others) to be included as possible words

this is because the 'a' in almeh is in the right ('fixed') location, and the two checks for 'elsewhere' marked letters (at index 2 for start, and index 3 for avian) evaluate to true (the letter is in the word && not at either of those indices)

this is an attempt to change that behaviour - also there is a gitignore

<img width="349" alt="Screenshot 2022-02-24 at 12 55 10" src="https://user-images.githubusercontent.com/44435064/155552418-2312b763-f300-46f6-872c-e0205b95a281.png">

