### PR TITLE
trying again without pep8 formatting

### DIFF
--- a/wordle3.py
+++ b/wordle3.py
@@ -16,6 +16,7 @@ https://github.com/Kinkelin/WordleCompetition
 
 """
 import sys
+import re
 from stats import score_words, sort_by_score, sort_by_usage
 import json
 #from english_words import english_words_lower_alpha_set
@@ -179,7 +180,7 @@ class ApplicationWindow(QtWidgets.QMainWindow):
                             break
             return newlist
 
-        def edit_elim_positional(wlist, letter, psn):
+        def edit_elim_positional(wlist, letter, psn, nom):
             """
             remove words that:
                 - don't have that letter at all
@@ -187,7 +188,7 @@ class ApplicationWindow(QtWidgets.QMainWindow):
             """
             newlist = []
             for w in wlist:
-                if not (w[psn] == letter or letter not in w):
+                if w[psn] != letter and letter in w and nom <= len(list(re.finditer(letter, w))):
                     newlist += [w]
             return newlist
 
@@ -252,7 +253,12 @@ class ApplicationWindow(QtWidgets.QMainWindow):
                 if letter == '':
                     continue
                 if b.state == ST_ELSEWHERE:
-                    newlist = edit_elim_positional(newlist, letter, k)
+                    # get other 'elsewhere's for the same letter, the number
+                    # of matches in the target word should be at least as large
+                    # the number of elsewheres
+                    nom = len([box for box in r if box.text() ==
+                              letter and box.state != ST_REJECT])
+                    newlist = edit_elim_positional(newlist, letter, k, nom)
 
 
         if self.sort_button_score.isChecked():


### PR DESCRIPTION
sometimes, the 'marked' letters imply that a letter 'elsewhere' must appear in the target word a minimum number of times

in the screenshot attached the wordle is 'alpha' and the guesses are 'start' and 'avian'

the previous implementaion would allow 'almeh' (among others) to be included as possible words

this is because the 'a' in almeh is in the right ('fixed') location, and the two checks for 'elsewhere' marked letters (at index 2 for start, and index 3 for avian) evaluate to true (the letter is in the word && not at either of those indices)

however, almeh is not 'possible' because we know that the letter 'a' is both 'fixed' and 'elsewhere' - which implies that only words with at least 2 occurrences of the letter 'a' should be allowed

this is an attempt to enforce that in the _edit_elim_positional_ filter

<img width="349" alt="Screenshot 2022-02-24 at 12 55 10" src="https://user-images.githubusercontent.com/44435064/155556085-bd72a97a-a46e-4ad7-bd78-2959809c5b24.png">

